### PR TITLE
fix(init): add waiting with admin promise

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   async getSuperAdminRole() {
+    await strapi.admin.services.role.createRolesIfNoneExist();
     let superAdminRole = await strapi.db.query("admin::role").findOne({
       select: [],
       where: { code: "strapi-super-admin" },


### PR DESCRIPTION
It seems that waiting for the `strapi.admin.services.role.createRolesIfNoneExist` promise is necessary before creating the role : https://forum.strapi.io/t/strapi-v4-how-to-bootstrap-some-data/20437/3. 

Solve the role overwriting problem for Strapi version above  4.4.x

